### PR TITLE
US 54 - Validar criação de Formulário

### DIFF
--- a/ForumDEG/ForumDEG/ViewModels/NewFormViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/NewFormViewModel.cs
@@ -107,6 +107,11 @@ namespace ForumDEG.ViewModels {
             if (IsFieldBlank(Title)) {
                 ActivityIndicator = false;
                 await _pageService.DisplayAlert("Formulário não pode ser criado", "O formulário deve possuir título", "ok");
+                return;
+            } else if (AreQuestionsListsEmpty()) {
+                ActivityIndicator = false;
+                await _pageService.DisplayAlert("Formulário não pode ser criado", "É necessário criar ao menos uma pergunta", "ok");
+                return; 
             } else if (await _formService.PostFormAsync(this)) {
                 ActivityIndicator = false;
                 await _dialog.AlertAsync("O formulário foi criado com sucesso. Os coordenadores serão notificados em breve."
@@ -121,5 +126,11 @@ namespace ForumDEG.ViewModels {
             
         }
         
+        public bool AreQuestionsListsEmpty() {
+            if (MultipleChoiceQuestions.Count == 0 && DiscursiveQuestionsTitles.Count == 0) {
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/UnitTest/UnitTests/NewFormViewModelTests.cs
+++ b/UnitTest/UnitTests/NewFormViewModelTests.cs
@@ -38,5 +38,25 @@ namespace Tests {
             viewModel.SelectedQuestion = test;
             Assert.AreSame(test, viewModel.SelectedQuestion);
         }
+        [Test()]
+        public void NewFormViewModel_QuestionsListsValidation_EmptyLists() {
+            Assert.True(viewModel.AreQuestionsListsEmpty());
+        }
+        [Test()]
+        public void NewFormViewModel_QuestionsListsValidation_EmptyDiscursive() {
+            viewModel.MultipleChoiceQuestions.Add(new QuestionDetailViewModel {
+                Title = "test",
+                MultipleAnswers = true,
+                Options = new System.Collections.ObjectModel.ObservableCollection<string> {
+                    "test"
+                }
+            });
+            Assert.False(viewModel.AreQuestionsListsEmpty());
+        }
+        [Test()]
+        public void NewFormViewModel_QuestionsListsValidation_EmptyMultipleChoice() {
+            viewModel.DiscursiveQuestionsTitles.Add("questão");
+            Assert.False(viewModel.AreQuestionsListsEmpty());
+        }
     }
 }


### PR DESCRIPTION
# US 54 - Validar criação de Formulário

## Descrição - O que o _Pull Request_ faz
Este _pull request_ adiciona a validação para a criação de formulários, enviando mensagem de erro caso não existam perguntas.

[Referência para a descrição do UC/US](https://github.com/fga-gpp-mds/2017.1-Forum-Coordenadores-DEG/issues/93)

## Porque o _Pull Request_ é necessário
Para a integridade do funcionamento do sistema de formulários.

## Critérios

- [x] Testes criados
- [x] Testes passando
- [x] Build passando
- [x] Não existem conflitos com a `master` - Se sim utilize do `git rebase`

resolve #93 
