### PR TITLE
[Back-End] Fixing Display Alerts

### DIFF
--- a/ForumDEG/ForumDEG/ViewModels/FormDetailViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/FormDetailViewModel.cs
@@ -156,7 +156,7 @@ namespace ForumDEG.ViewModels {
             ActivityIndicator = true;
             foreach (SingleAnswerQuestion radioButtonQuestion in SingleAnswerQuestions) {
                 if (radioButtonQuestion.SelectedOption == -1) {
-                    Debug.WriteLine("nenhuma quest�o selecionada");
+                    Debug.WriteLine("nenhuma questão selecionada");
                     ActivityIndicator = false;
                     return false;
                 }
@@ -183,22 +183,22 @@ namespace ForumDEG.ViewModels {
 
         public async Task blankAnswerAsync() {
             ActivityIndicator = false;
-            await _pageService.DisplayAlert("Erro!", "Voce deve selecionar pelo menos uma op��o!", "ok", "cancel");
+            await _pageService.DisplayAlert("Erro!", "Você deve selecionar pelo menos uma opção", "ok", "cancel");
         }
 
         private async void DeleteForm() {
-            var answer = await _pageService.DisplayAlert("Deletar Formul�rio", "Tem certeza que deseja deletar o Formul�rio existente? Esta altera��o n�o poder� ser desfeita.", "Sim", "N�o");
+            var answer = await _pageService.DisplayAlert("Deletar Formulário", "Tem certeza que deseja deletar o Formulário existente? Esta alteração não poderá ser desfeita.", "Sim", "Não");
             ActivityIndicator = true;
             Debug.WriteLine("Answer: " + answer);
             if (answer == true) {
                 if (await _formService.DeleteFormAsync(RemoteId)) {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Formul�rio Deletado !", "O Formul�rio foi deletado com sucesso.", null, "OK");
+                    await _pageService.DisplayAlert("Formulário Deletado !", "O Formulário foi deletado com sucesso.", null, "OK");
                     await _pageService.PopToRootAsync();
                 }
                 else {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Erro!", "O formul�rio n�o pode ser deletado, tente novamente.", "OK", "Cancelar");
+                    await _pageService.DisplayAlert("Erro!", "O formulário não pode ser deletado, tente novamente.", "OK", "Cancelar");
                 }
             }
             ActivityIndicator = false;

--- a/ForumDEG/ForumDEG/ViewModels/FormsViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/FormsViewModel.cs
@@ -125,7 +125,7 @@ namespace ForumDEG.ViewModels {
                 Debug.WriteLine("[Update forms list] " + ex.Message + "\n" + ex.StackTrace);
                 await _pageService.DisplayAlert("Falha ao carregar formulários",
                                           "Houve um erro ao estabelecer conexão com o servidor. Por favor, tente novamente.",
-                                          "Ok", "Cancel");
+                                          null, "OK");
                 await _pageService.PopAsync();
             }
         }

--- a/ForumDEG/ForumDEG/ViewModels/ForumEditViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/ForumEditViewModel.cs
@@ -139,17 +139,17 @@ namespace ForumDEG.ViewModels {
         public async Task EditForum() {
             if (await _forumService.PutForumAsync(Forum.RemoteId, Forum) ){
                 ActivityIndicator = false;
-                await _pageService.DisplayAlert("Editar Fórum", "O fórum foi editado com sucesso!", "OK", "Cancelar");
+                await _pageService.DisplayAlert("Editar Fórum", "O fórum foi editado com sucesso!", null ,"OK");
             } else {
                 ActivityIndicator = false;
-                await _pageService.DisplayAlert("Erro!", "O fórum não pôde ser editado. Tente novamente!", "OK", "Cancelar");
+                await _pageService.DisplayAlert("Erro!", "O fórum não pôde ser editado. Tente novamente!", null, "OK");
             }
         }
 
         public async void EditionFailed() {
             await _pageService.DisplayAlert("Erro na Edição"
                 , "O fórum não foi editado. Você deve preencher todos os campos."
-                , "OK", "cancel");
+                , null ,"OK");
         }
 
         public async void Cancel() {

--- a/ForumDEG/ForumDEG/ViewModels/ForumsViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/ForumsViewModel.cs
@@ -124,7 +124,7 @@ namespace ForumDEG.ViewModels {
                 Debug.WriteLine("[Update forums list] " + ex.Message);
                 await _pageService.DisplayAlert("Falha ao carregar fóruns",
                                           "Houve um erro ao estabelecer conexão com o servidor. Por favor, tente novamente.",
-                                          "Ok", "Cancel");
+                                          null ,"Ok");
                 await _pageService.PopAsync();
             }
         }

--- a/ForumDEG/ForumDEG/ViewModels/UserDetailViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/UserDetailViewModel.cs
@@ -70,11 +70,11 @@ namespace ForumDEG.ViewModels {
                     ActivityIndicator = true;
                     if (await _administratorService.DeleteAdministratorAsync(Registration)) {
                         ActivityIndicator = false;
-                        await _pageService.DisplayAlert("Usuário deletado", "O usuário foi excluído do sistema com sucesso.", "OK");
+                        await _pageService.DisplayAlert("Usuário deletado", "O usuário foi excluído do sistema com sucesso.", null,"OK");
                         await _pageService.PopToRootAsync();
                     } else {
                         ActivityIndicator = false;
-                        await _pageService.DisplayAlert("Erro!", "O usuário não pôde ser deletado, tente novamente.", "OK");
+                        await _pageService.DisplayAlert("Erro!", "O usuário não pôde ser deletado, tente novamente.",null ,"OK");
                     }
                 }
                       //LOCAL DATABASE//
@@ -95,11 +95,11 @@ namespace ForumDEG.ViewModels {
                     if (await _coordinatorService.DeleteCoordinatorAsync(Registration)) {
                         ActivityIndicator = false;
                         await _pageService.PopAsync();
-                        await _pageService.DisplayAlert("Usuário deletado", "O usuário foi excluído do sistema com sucesso.", "OK");
+                        await _pageService.DisplayAlert("Usuário deletado", "O usuário foi excluído do sistema com sucesso.", null,"OK");
                         await _pageService.PopToRootAsync();
                     } else {
                         ActivityIndicator = false;
-                        await _pageService.DisplayAlert("Erro!", "O usuário não pôde ser deletado, tente novamente.", "OK", "Cancelar");
+                        await _pageService.DisplayAlert("Erro!", "O usuário não pôde ser deletado, tente novamente.", null, "OK");
                     }
                 }
                 //LOCAL DATABASE//

--- a/ForumDEG/ForumDEG/ViewModels/UserEditViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/UserEditViewModel.cs
@@ -229,17 +229,17 @@ namespace ForumDEG.ViewModels {
                     }
                     else {
                         ActivityIndicator = false;
-                        await _pageService.DisplayAlert("Erro!", "A senha deve conter de 8 a 15 caracteres, pelo menos uma letra maiúscula e uma minúscula, e pelo menos um número.", "ok", "cancel");
+                        await _pageService.DisplayAlert("Erro!", "A senha deve conter de 8 a 15 caracteres, pelo menos uma letra maiúscula e uma minúscula, e pelo menos um número.", null, "OK");
                     }
                 }
                 else {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Erro!", "Email Inválido! Insira-o novamente.", "ok", "cancel");
+                    await _pageService.DisplayAlert("Erro!", "Email Inválido! Insira-o novamente.", null, "OK");
                 }
             }
             else {
                 ActivityIndicator = false;
-                await _pageService.DisplayAlert("Erro!", "Você deve preencher todos os campos disponíveis!", "ok", "cancel");
+                await _pageService.DisplayAlert("Erro!", "Você deve preencher todos os campos disponíveis!", null, "OK");
             }
         }
 
@@ -255,11 +255,11 @@ namespace ForumDEG.ViewModels {
 
                 if (await _coordinatorService.PutCoordinatorAsync(Coordinator.Registration, Coordinator)) {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Editar Usuário", "Usuário editado com sucesso!", "OK", "Cancelar");
+                    await _pageService.DisplayAlert("Editar Usuário", "Usuário editado com sucesso!", null, "OK");
                 }
                 else {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Editar Usuário", "O usuário selecionado não pôde ser editado. Tente novamente!", "OK", "Cancelar");
+                    await _pageService.DisplayAlert("Editar Usuário", "O usuário selecionado não pôde ser editado. Tente novamente!", null, "OK");
                 }
 
             }
@@ -271,11 +271,11 @@ namespace ForumDEG.ViewModels {
 
                 if (await _administratorService.PutAdministratorAsync(Administrator.Registration, Administrator)) {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Editar Usuário", "Usuário editado com sucesso!", "OK", "Cancelar");
+                    await _pageService.DisplayAlert("Editar Usuário", "Usuário editado com sucesso!", null, "OK");
                 }
                 else {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Editar Usuário", "O usuário selecionado não pôde ser editado. Tente novamente!", "OK", "Cancelar");
+                    await _pageService.DisplayAlert("Editar Usuário", "O usuário selecionado não pôde ser editado. Tente novamente!", null, "OK");
                 }
             }
         }
@@ -284,7 +284,7 @@ namespace ForumDEG.ViewModels {
             ActivityIndicator = false;
             await _pageService.DisplayAlert("Erro na Edição"
                 , "O usuário não foi editado. Você deve preencher todos os campos."
-                , "OK", "cancel");
+                , null, "OK");
         }
 
         public async void Cancel() {

--- a/ForumDEG/ForumDEG/ViewModels/UserRegistrationViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/UserRegistrationViewModel.cs
@@ -237,23 +237,23 @@ namespace ForumDEG.ViewModels {
                         }
                         else {
                             ActivityIndicator = false;
-                            await _pageService.DisplayAlert("Erro!", "A senha deve conter de 8 a 15 caracteres, pelo menos uma letra maiúscula e uma minúscula, e pelo menos um número.", "ok", "cancel");
+                            await _pageService.DisplayAlert("Erro!", "A senha deve conter de 8 a 15 caracteres, pelo menos uma letra maiúscula e uma minúscula, e pelo menos um número.", null, "OK");
                         }
 
                     }
                     else {
                         ActivityIndicator = false;
-                        await _pageService.DisplayAlert("Erro!", "Matrícula Inválida!", "ok", "cancel");
+                        await _pageService.DisplayAlert("Erro!", "Matrícula Inválida!", null, "OK");
                     }
                 }
                 else {
                     ActivityIndicator = false;
-                    await _pageService.DisplayAlert("Erro!", "Email Inválido! Insira-o novamente.", "ok", "cancel");
+                    await _pageService.DisplayAlert("Erro!", "Email Inválido! Insira-o novamente.", null, "OK");
                 }
             }
             else {
                 ActivityIndicator = false;
-                await _pageService.DisplayAlert("Erro!", "Você deve preencher todos os campos disponíveis!", "ok", "cancel");
+                await _pageService.DisplayAlert("Erro!", "Você deve preencher todos os campos disponíveis!", null, "OK");
             }
         }
 
@@ -269,14 +269,12 @@ namespace ForumDEG.ViewModels {
             if (await _administratorService.PostAdministratorAsync(Admin)) {
                 ActivityIndicator = false;
                 await _pageService.DisplayAlert("Registrar novo usuário",
-                                                "Você salvou um novo adminstrador com sucesso! ",
-                                                "ok", "cancel");
+                                                "Você salvou um novo adminstrador com sucesso! ", null, "OK");
             }
             else {
                 ActivityIndicator = false;
                 await _pageService.DisplayAlert("Falha na conexão com o servidor",
-                                                "Não foi possível cadastrar o administrador. Por favor tente novamente.",
-                                                "ok", "cancel");
+                                                "Não foi possível cadastrar o administrador. Por favor tente novamente.", null, "OK");
                 Debug.WriteLine("[URVM] Couldn't save.");
             }
         }
@@ -293,14 +291,12 @@ namespace ForumDEG.ViewModels {
             if (await _coordinatorService.PostCoordinatorAsync(Coord)) {
                 ActivityIndicator = false;
                 await _pageService.DisplayAlert("Registrar novo usuário",
-                                                "Você salvou um novo Coordenador com sucesso!",
-                                                "ok", "cancel");
+                                                "Você salvou um novo Coordenador com sucesso!", null, "OK");
             }
             else {
                 ActivityIndicator = false;
                 await _pageService.DisplayAlert("Falha na conexão com o servidor",
-                                                "Não foi possível cadastrar o coordenador. Por favor tente novamente.",
-                                                "ok", "cancel");
+                                                "Não foi possível cadastrar o coordenador. Por favor tente novamente.", null, "OK");
                 Debug.WriteLine("[URVM] Couldn't save.");
             }
         }

--- a/ForumDEG/ForumDEG/ViewModels/UsersViewModel.cs
+++ b/ForumDEG/ForumDEG/ViewModels/UsersViewModel.cs
@@ -145,8 +145,7 @@ namespace ForumDEG.ViewModels {
                 IsLoaded = true;
                 Debug.WriteLine("[Update users list] " + ex.Message);
                 await _pageService.DisplayAlert("Falha ao carregar usuários",
-                                          "Houve um erro ao estabelecer conexão com o servidor. Por favor, tente novamente.",
-                                          "Ok", "Cancel");
+                                          "Houve um erro ao estabelecer conexão com o servidor. Por favor, tente novamente.", null, "OK");
                 await _pageService.PopAsync();
 
             }


### PR DESCRIPTION
# US53 - Refatorar mensagens de Display Alert

## Descrição - O que o _Pull Request_ faz
Refatora as mensagens dos respectivos displays de cada página, para que não ocorram incoerências

#### US53(https://github.com/fga-gpp-mds/2017.1-Forum-Coordenadores-DEG/issues/92)

## Porque o _Pull Request_ é necessário
Para que não ocorram incoerências no uso do aplicativo. 

## Critérios

- [x] Testes criados
- [x] Testes passando
- [x] Build passando
- [x] Não existem conflitos com a `master` - Se sim utilize do `git rebase`

resolve #92 
